### PR TITLE
Fix fast-glob to handle config loading on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@unshopable/melter",
-  "version": "0.1.0-alpha.32",
+  "version": "0.1.0-alpha.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@unshopable/melter",
-      "version": "0.1.0-alpha.32",
+      "version": "0.1.0-alpha.34",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^3.5.3",
-        "fast-glob": "^3.2.12",
+        "fast-glob": "^3.3.0",
         "fs-extra": "^11.1.1",
         "just-safe-get": "^4.2.0",
         "just-safe-set": "^4.2.1",
@@ -791,9 +791,9 @@
       }
     },
     "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.0.tgz",
+      "integrity": "sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "chokidar": "^3.5.3",
-    "fast-glob": "^3.2.12",
+    "fast-glob": "^3.3.0",
     "fs-extra": "^11.1.1",
     "just-safe-get": "^4.2.0",
     "just-safe-set": "^4.2.1",

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -7,7 +7,7 @@ import { getFilenameFromPath, parseJSON } from '../utils';
 function getConfigFiles(cwd: string): string[] {
   const configFilePattern = 'melter.config.*';
 
-  return fg.sync(fg.convertPathToPattern(path.join(cwd, configFilePattern)));
+  return fg.sync(fg.convertPathToPattern(cwd) + '/' + configFilePattern);
 }
 
 function parseConfigFile(file: string): { config: MelterConfig | null; errors: string[] } {

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -7,7 +7,7 @@ import { getFilenameFromPath, parseJSON } from '../utils';
 function getConfigFiles(cwd: string): string[] {
   const configFilePattern = 'melter.config.*';
 
-  return fg.sync(path.join(cwd, configFilePattern));
+  return fg.sync(fg.convertPathToPattern(path.join(cwd, configFilePattern)));
 }
 
 function parseConfigFile(file: string): { config: MelterConfig | null; errors: string[] } {

--- a/src/config/load.ts
+++ b/src/config/load.ts
@@ -6,7 +6,7 @@ import { getFilenameFromPath, parseJSON } from '../utils';
 
 function getConfigFiles(cwd: string): string[] {
   const configFilePattern = 'melter.config.*';
-
+  // flat-glob only supports POSIX path syntax, so we use convertPathToPattern() for windows
   return fg.sync(fg.convertPathToPattern(cwd) + '/' + configFilePattern);
 }
 


### PR DESCRIPTION
<!--
  ☝️ How to write a good PR title:
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Write in present tense
  - Give as much context as necessary and as little as possible
  - Use a draft PR while it’s a work in progress
-->

### Summary

Updated fast-glob to 3.3.0 for support of [convertPathToPattern()](https://github.com/mrmlnc/fast-glob/releases/tag/3.3.0).
Used it, to convert windows path to compatible pattern.
<!--
  Please include a short description (using non-technical terms, 1-2 sentences)
  about the changes you are introducing and/or what problem is being fixed.
-->

### Why are these changes introduced?

see: https://github.com/mrmlnc/fast-glob/issues/237#issuecomment-546057189
<!--
  Give context to help reviewers fully understand your changes.
  Also add the link to the corresponding issue if one exists.
-->

### What approach did you take?

<!--
  What approach did you take, and why? Were there any other approaches
  you considered using, and why did you decide to drop them?
-->

### How did you test the change(s) to make sure everything is working properly?

can't really test with current setup. any suggestions @davidthorand 
<!--
  List all testing steps/scenarios you checked and help peers to review your changes.
-->
